### PR TITLE
Explicitly install yarn

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,10 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: 20
+    - name: Install Yarn
+      run: npm install -g yarn
+    - name: Verify Yarn Installation
+      run: yarn --version
     - name: Set up Java
       uses: actions/setup-java@v4
       with:

--- a/save_image.sh
+++ b/save_image.sh
@@ -36,7 +36,7 @@ echo "Files copied successfully."
 # Commit the container with the specified changes
 echo "Committing the container..."
 docker commit \
-  --change 'ENV PATH="$PATH:/opt/acttoolcache/Java_Temurin-Hotspot_jdk/21.0.5-11.0.LTS/x64/bin:/opt/acttoolcache/Ruby/3.3.6/x64/bin:/opt/acttoolcache/go/1.23.4/x64/bin:/opt/acttoolcache/go/workspace/bin:/usr/share/dotnet:/opt/acttoolcache/node/20.18.1/x64/bin"' \
+  --change 'ENV PATH="/opt/acttoolcache/node/20.18.1/x64/bin:$PATH:/opt/acttoolcache/Java_Temurin-Hotspot_jdk/21.0.5-11.0.LTS/x64/bin:/opt/acttoolcache/Ruby/3.3.6/x64/bin:/opt/acttoolcache/go/1.23.4/x64/bin:/opt/acttoolcache/go/workspace/bin:/usr/share/dotnet"' \
   --change 'ENV JAVA_HOME="/opt/acttoolcache/Java_Temurin-Hotspot_jdk/21.0.5-11.0.LTS/x64"' \
   --change 'ENV GEM_HOME="/opt/hostedtoolcache/Ruby/3.3.6/x64/lib/ruby/gems"' \
   --change 'ENV GEM_PATH="/opt/hostedtoolcache/Ruby/3.3.6/x64/lib/ruby/gems"' \

--- a/save_image.sh
+++ b/save_image.sh
@@ -36,7 +36,7 @@ echo "Files copied successfully."
 # Commit the container with the specified changes
 echo "Committing the container..."
 docker commit \
-  --change 'ENV PATH="$PATH:/opt/acttoolcache/Java_Temurin-Hotspot_jdk/21.0.5-11.0.LTS/x64/bin:/opt/acttoolcache/Ruby/3.3.6/x64/bin:/opt/acttoolcache/go/1.23.4/x64/bin:/opt/acttoolcache/go/workspace/bin:/usr/share/dotnet"' \
+  --change 'ENV PATH="$PATH:/opt/acttoolcache/Java_Temurin-Hotspot_jdk/21.0.5-11.0.LTS/x64/bin:/opt/acttoolcache/Ruby/3.3.6/x64/bin:/opt/acttoolcache/go/1.23.4/x64/bin:/opt/acttoolcache/go/workspace/bin:/usr/share/dotnet:/opt/acttoolcache/node/20.18.1/x64/bin"' \
   --change 'ENV JAVA_HOME="/opt/acttoolcache/Java_Temurin-Hotspot_jdk/21.0.5-11.0.LTS/x64"' \
   --change 'ENV GEM_HOME="/opt/hostedtoolcache/Ruby/3.3.6/x64/lib/ruby/gems"' \
   --change 'ENV GEM_PATH="/opt/hostedtoolcache/Ruby/3.3.6/x64/lib/ruby/gems"' \


### PR DESCRIPTION
When I do `act --reuse` and docker exec into the container, I do not see the `yarn` executable in `/opt/hostedtoolcache/node`. After I install yarn explicitly, I can see the `yarn` executable under `/opt/hostedtoolcache/node/`.

After running `bash save_image.sh` and executing the resulting container, `yarn --version` succeeds.